### PR TITLE
fixing wishart import error; file missing and not required

### DIFF
--- a/volatilitygp/likelihoods/__init__.py
+++ b/volatilitygp/likelihoods/__init__.py
@@ -1,6 +1,5 @@
 from .volatility_likelihood import VolatilityGaussianLikelihood
 from .fixed_noise_gaussian_likelihood import FixedNoiseGaussianLikelihood
-from .wishart_likelihood import WishartLikelihood, InverseWishartLikelihood
 from .preference_learning_likelihood import PrefLearningLikelihood
 from .poisson_likelihood import PoissonLikelihood
 from .multivariate_normal_likelihood import (


### PR DESCRIPTION
`__init__.py` in likelihoods has an import for `wishart_likelihood.py` which is missing because of which experiments can't run and exit with an error. It is not used anywhere so just deleted the import.